### PR TITLE
REC binaryQuant and intNoteScale objects

### DIFF
--- a/objects/rec/harmony/binaryQuant.axo
+++ b/objects/rec/harmony/binaryQuant.axo
@@ -1,0 +1,103 @@
+<objdefs appVersion="1.0.12">
+   <obj.normal id="binaryQuant" uuid="7e8bf3d6-b685-43ec-b5d3-3d4db2a3a8f8">
+      <sDescription>quantize note input to a scale where scale is specified by 12 boolean inputs</sDescription>
+      <author>Reductionist Earth Catalog</author>
+      <license>GPL</license>
+      <helpPatch>harmony.axh</helpPatch>
+      <inlets>
+         <frac32.bipolar name="note"/>
+         <bool32 name="c"/>
+         <bool32 name="csh"/>
+         <bool32 name="d"/>
+         <bool32 name="dsh"/>
+         <bool32 name="e"/>
+         <bool32 name="f"/>
+         <bool32 name="fsh"/>
+         <bool32 name="g"/>
+         <bool32 name="gsh"/>
+         <bool32 name="a"/>
+         <bool32 name="ash"/>
+         <bool32 name="b"/>
+      </inlets>
+      <outlets>
+         <frac32.bipolar name="note" description="note number (-64..63)"/>
+         <bool32 name="change" description="triggers on new quantized note"/>
+      </outlets>
+      <displays/>
+      <params/>
+      <attribs/>
+      <code.declaration><![CDATA[int32_t	_scaleVal;
+float	_last_note;
+int32_t	_out;
+int32_t	_last_out_note;
+int		_midi_notes[252];
+int32_t	_last_scale;
+int		_gate_hi_counter;
+int		_nb_waits;
+bool		_storedbin[12];
+bool		_lastbin[12];]]></code.declaration>
+      <code.init><![CDATA[_nb_waits = 1;]]></code.init>
+      <code.krate><![CDATA[// collect inlet bools into storedbin
+_storedbin[0] = inlet_a;
+_storedbin[1] = inlet_ash;
+_storedbin[2] = inlet_d;
+_storedbin[3] = inlet_dsh;
+_storedbin[4] = inlet_e;
+_storedbin[5] = inlet_f;
+_storedbin[6] = inlet_fsh;
+_storedbin[7] = inlet_g;
+_storedbin[8] = inlet_gsh;
+_storedbin[9] = inlet_a;
+_storedbin[10] = inlet_ash;
+_storedbin[11] = inlet_b;
+
+// calculate new lookup table when scale is updated
+if (_lastbin != _storedbin) {
+	for(int i=0; i<12; i++){
+		_lastbin[i] = _storedbin[i];
+	}
+	//_lastbin = _storedbin;
+	int offset = 8; // aloloti treats 0 as E
+	for(int i=0; i<12; i++){
+    		for(int octave=0; octave<20; octave++){
+    			if((_storedbin[i]) << 21){
+    				_midi_notes[i + octave*12 + offset] = i + octave*12;
+    			} else {
+    				_midi_notes[i + octave*12 + offset] = -1;
+    			}
+    		}
+    }
+ }
+
+if (_last_note != inlet_note) {
+	_last_note = inlet_note;	
+
+  	int _initial_guess;
+	int guess;
+
+	// handle negative numbers
+  	_initial_guess = (inlet_note >> 21) + 120;
+  	
+	for(guess=_initial_guess; guess >=0; guess--){
+		if(_midi_notes[guess] > -1){
+			// appropiate note found
+			_out = (guess-120) << 21;
+			if(_out != _last_out_note){
+				// new value on note outlet
+				outlet_change = true;
+				_gate_hi_counter = _nb_waits;
+				_last_out_note = _out;
+			}
+			guess = -1; // leave loop
+		}
+	}
+}
+
+// set change outlet low after _nb_waits cycles
+if(_gate_hi_counter-- < 1){
+	outlet_change = false;
+}
+
+outlet_note = _out;]]></code.krate>
+   </obj.normal>
+</objdefs>

--- a/objects/rec/harmony/binaryQuant.axo
+++ b/objects/rec/harmony/binaryQuant.axo
@@ -1,6 +1,6 @@
 <objdefs appVersion="1.0.12">
    <obj.normal id="binaryQuant" uuid="7e8bf3d6-b685-43ec-b5d3-3d4db2a3a8f8">
-      <sDescription>quantize note input to a scale where scale is specified by 12 boolean inputs</sDescription>
+      <sDescription>quantize note input to a scale where scale is specified by 12 boolean inputs, modified from a773/quantizer</sDescription>
       <author>Reductionist Earth Catalog</author>
       <license>GPL</license>
       <helpPatch>harmony.axh</helpPatch>

--- a/objects/rec/harmony/harmony.axh
+++ b/objects/rec/harmony/harmony.axh
@@ -1,0 +1,303 @@
+<patch-1.0 appVersion="1.0.12">
+   <comment type="patch/comment" x="196" y="42" text="play scale"/>
+   <obj type="lfo/square" uuid="de6909eb64db13af5b43f979a4c130024b3a4793" name="square_1" x="56" y="56">
+      <params>
+         <frac32.s.map name="pitch" value="5.0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="logic/counter" uuid="7a141ba82230e54e5f5cd12da5dbe5a74ba854a5" name="counter_1" x="196" y="56">
+      <params>
+         <int32 name="maximum" value="28"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/i radio 4 v" uuid="b610704137c90b0e43464440b84bfb4fb7d2bb30" name="toggle_13" x="462" y="56">
+      <params>
+         <int32.vradio name="value" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="mux/mux 4" uuid="bd572dad58644793774a69385f376bda2e1fd9be" name="mux_1" x="588" y="56">
+      <params/>
+      <attribs/>
+   </obj>
+   <comment type="patch/comment" x="896" y="70" text="show note number"/>
+   <obj type="disp/note" uuid="ce3190ad98b73b468f22221f555b01feee03226a" name="dial_1" x="896" y="84">
+      <params/>
+      <attribs/>
+   </obj>
+   <comment type="patch/comment" x="882" y="140" text="set which notes are part of scale"/>
+   <obj type="osc/saw" uuid="739ecc36017ef3249479b8f01716b8bbfba9abc1" name="sine_1" x="1176" y="154">
+      <params>
+         <frac32.s.map name="pitch" value="0.0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="filter/lp1 m" uuid="18b561d14f9175f5380e6a1d9d55ca41e0e61974" name="lp_1" x="1330" y="154">
+      <params>
+         <frac32.u.map name="freq" value="20.5"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="gain/vca" uuid="a9f2dcd18043e2f47364e45cb8814f63c2a37c0d" name="vca_1" x="1414" y="154">
+      <params/>
+      <attribs/>
+   </obj>
+   <obj type="audio/out stereo" uuid="a1ca7a567f535acc21055669829101d3ee7f0189" name="out_1" x="1512" y="154">
+      <params/>
+      <attribs/>
+   </obj>
+   <comment type="patch/comment" x="196" y="182" text="play sequence"/>
+   <obj type="logic/counter" uuid="7a141ba82230e54e5f5cd12da5dbe5a74ba854a5" name="counter_2" x="126" y="196">
+      <params>
+         <int32 name="maximum" value="16"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="sel/sel fb 16" uuid="f4aa3eb141915b6fc722e576dde344a226a022ac" name="sel_1" x="196" y="196">
+      <params>
+         <frac32.s.mapvsl name="b0" value="18.0"/>
+         <frac32.s.mapvsl name="b1" value="0.0"/>
+         <frac32.s.mapvsl name="b2" value="14.0"/>
+         <frac32.s.mapvsl name="b3" value="-4.0"/>
+         <frac32.s.mapvsl name="b4" value="9.0"/>
+         <frac32.s.mapvsl name="b5" value="-6.0"/>
+         <frac32.s.mapvsl name="b6" value="8.0"/>
+         <frac32.s.mapvsl name="b7" value="16.0"/>
+         <frac32.s.mapvsl name="b8" value="-7.0"/>
+         <frac32.s.mapvsl name="b9" value="5.0"/>
+         <frac32.s.mapvsl name="b10" value="-6.0"/>
+         <frac32.s.mapvsl name="b11" value="-7.0"/>
+         <frac32.s.mapvsl name="b12" value="-7.0"/>
+         <frac32.s.mapvsl name="b13" value="-9.0"/>
+         <frac32.s.mapvsl name="b14" value="7.0"/>
+         <frac32.s.mapvsl name="b15" value="15.0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="lfo/sine" uuid="75f7330c26a13953215dccc3b7b9008545c9daa9" name="saw_1" x="1092" y="238">
+      <params>
+         <frac32.s.map name="pitch" value="21.0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="math/*c" uuid="7d5ef61c3bcd571ee6bbd8437ef3612125dfb225" name="*c_1" x="1190" y="238">
+      <params>
+         <frac32.u.map name="amp" value="23.5"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="env/ad" uuid="255cb0cd67470c7498f9c33b820facd26aa629ce" name="ad_1" x="1330" y="252">
+      <params>
+         <frac32.s.map name="a" value="-64.0"/>
+         <frac32.s.map name="d" value="10.0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <comment type="patch/comment" x="686" y="378" text="This help patch is a placeholder until rec objects are part of the ksoloti-contrib library"/>
+   <comment type="patch/comment" x="196" y="420" text="play random"/>
+   <obj type="rand/uniform i" uuid="9b1f945f346af0165ed99b8e19136cdbf744e594" name="uniform_1" x="196" y="434">
+      <params>
+         <int32 name="max" value="28"/>
+      </params>
+      <attribs/>
+   </obj>
+   <comment type="patch/comment" x="672" y="546" text="Converting note toggle to 12-bit integer"/>
+   <obj type="sptnk/logic/encode 16" uuid="dfc0a6e9d7e237cec64fd01f6972f64d897863a4" name="encode_1" x="672" y="560">
+      <params/>
+      <attribs/>
+   </obj>
+   <obj type="disp/i" uuid="5e35fd0c62d81e70017289250cf28edd26e19e4a" name="i_1" x="798" y="560">
+      <params/>
+      <attribs/>
+   </obj>
+   <comment type="patch/comment" x="154" y="630" text="Note toggles for notes in scale"/>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_2" x="196" y="644">
+      <params>
+         <bool32.tgl name="b" value="0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_4" x="266" y="644">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_7" x="406" y="644">
+      <params>
+         <bool32.tgl name="b" value="0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_9" x="476" y="644">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_11" x="546" y="644">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_1" x="154" y="700">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_3" x="224" y="700">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_5" x="294" y="700">
+      <params>
+         <bool32.tgl name="b" value="0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_6" x="364" y="700">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_8" x="434" y="700">
+      <params>
+         <bool32.tgl name="b" value="1"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_10" x="504" y="700">
+      <params>
+         <bool32.tgl name="b" value="0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <obj type="ctrl/toggle" uuid="42b8134fa729d54bfc8d62d6ef3fa99498c1de99" name="toggle_12" x="574" y="700">
+      <params>
+         <bool32.tgl name="b" value="0"/>
+      </params>
+      <attribs/>
+   </obj>
+   <nets>
+      <net>
+         <source obj="toggle_1" outlet="o"/>
+         <dest obj="encode_1" inlet="b0"/>
+      </net>
+      <net>
+         <source obj="toggle_2" outlet="o"/>
+         <dest obj="encode_1" inlet="b1"/>
+      </net>
+      <net>
+         <source obj="toggle_3" outlet="o"/>
+         <dest obj="encode_1" inlet="b2"/>
+      </net>
+      <net>
+         <source obj="toggle_4" outlet="o"/>
+         <dest obj="encode_1" inlet="b3"/>
+      </net>
+      <net>
+         <source obj="toggle_5" outlet="o"/>
+         <dest obj="encode_1" inlet="b4"/>
+      </net>
+      <net>
+         <source obj="toggle_6" outlet="o"/>
+         <dest obj="encode_1" inlet="b5"/>
+      </net>
+      <net>
+         <source obj="toggle_7" outlet="o"/>
+         <dest obj="encode_1" inlet="b6"/>
+      </net>
+      <net>
+         <source obj="toggle_8" outlet="o"/>
+         <dest obj="encode_1" inlet="b7"/>
+      </net>
+      <net>
+         <source obj="toggle_9" outlet="o"/>
+         <dest obj="encode_1" inlet="b8"/>
+      </net>
+      <net>
+         <source obj="toggle_10" outlet="o"/>
+         <dest obj="encode_1" inlet="b9"/>
+      </net>
+      <net>
+         <source obj="toggle_11" outlet="o"/>
+         <dest obj="encode_1" inlet="b10"/>
+      </net>
+      <net>
+         <source obj="toggle_12" outlet="o"/>
+         <dest obj="encode_1" inlet="b11"/>
+      </net>
+      <net>
+         <source obj="encode_1" outlet="out"/>
+         <dest obj="i_1" inlet="in"/>
+      </net>
+      <net>
+         <source obj="square_1" outlet="wave"/>
+         <dest obj="counter_1" inlet="trig"/>
+         <dest obj="counter_2" inlet="trig"/>
+         <dest obj="uniform_1" inlet="trig"/>
+      </net>
+      <net>
+         <source obj="counter_2" outlet="o"/>
+         <dest obj="sel_1" inlet="in"/>
+      </net>
+      <net>
+         <source obj="sel_1" outlet="o"/>
+         <dest obj="mux_1" inlet="i1"/>
+      </net>
+      <net>
+         <source obj="uniform_1" outlet="v"/>
+         <dest obj="mux_1" inlet="i2"/>
+      </net>
+      <net>
+         <source obj="counter_1" outlet="o"/>
+         <dest obj="mux_1" inlet="i0"/>
+      </net>
+      <net>
+         <source obj="toggle_13" outlet="out"/>
+         <dest obj="mux_1" inlet="s"/>
+      </net>
+      <net>
+         <source obj="ad_1" outlet="env"/>
+         <dest obj="vca_1" inlet="v"/>
+      </net>
+      <net>
+         <source obj="vca_1" outlet="o"/>
+         <dest obj="out_1" inlet="left"/>
+         <dest obj="out_1" inlet="right"/>
+      </net>
+      <net>
+         <source obj="sine_1" outlet="wave"/>
+         <dest obj="lp_1" inlet="in"/>
+      </net>
+      <net>
+         <source obj="lp_1" outlet="out"/>
+         <dest obj="vca_1" inlet="a"/>
+      </net>
+      <net>
+         <source obj="saw_1" outlet="wave"/>
+         <dest obj="*c_1" inlet="in"/>
+      </net>
+      <net>
+         <source obj="*c_1" outlet="out"/>
+         <dest obj="lp_1" inlet="freq"/>
+      </net>
+   </nets>
+   <settings>
+      <subpatchmode>no</subpatchmode>
+   </settings>
+   <notes><![CDATA[]]></notes>
+   <windowPos>
+      <x>240</x>
+      <y>160</y>
+      <width>1423</width>
+      <height>854</height>
+   </windowPos>
+</patch-1.0>

--- a/objects/rec/harmony/intNoteScale.axo
+++ b/objects/rec/harmony/intNoteScale.axo
@@ -1,0 +1,75 @@
+<objdefs appVersion="1.0.12">
+   <obj.normal id="intNoteScale" uuid="939e3abc-1ecc-4805-b0b4-e4ab24e9ec80">
+      <sDescription>12 bit integer defines a scale (where 1s of binary string are allowed notes), note number and octave inputs are converted to a fractional note output
+      <author>Reductionist Earth Catalog</author>
+      <license>BSD</license>
+      <helpPatch>harmony.axh</helpPatch>
+      <inlets>
+         <int32 name="scale" description="12 bit integer specifying scale"/>
+         <int32 name="tonic" description="tonic note number"/>
+         <int32.bipolar name="octave"/>
+         <int32.bipolar name="degree"/>
+         <bool32 name="latch"/>
+      </inlets>
+      <outlets>
+         <frac32.bipolar name="note" description="note number (-64..63)"/>
+      </outlets>
+      <displays/>
+      <params/>
+      <attribs/>
+      <code.declaration><![CDATA[int32_t _scaleVal;
+    int8_t  _scale[12];
+    int8_t  _nscale;
+    int32_t  _note;
+    int32_t  _tonic;
+    int32_t  _octave;
+    int32_t  _out;
+    int32_t  _latch;
+    int32_t  _allowed[128];
+    int32_t  _degree;
+    int32_t  _notecount;
+    int32_t  _postrack;]]></code.declaration>
+      <code.init><![CDATA[_note = 0;
+    _scaleVal = 0;
+    _nscale = 0;
+    _tonic = 0;
+    _notecount = 0;
+    _postrack = 0;
+    _degree = 0;
+    for(int i=0;i<128;i++) {
+        if(i<12){
+        	_scale[i] = 0;
+        }
+        _allowed[i] = 0;
+    }]]></code.init>
+      <code.krate><![CDATA[_latch = inlet_latch;
+    if (_scaleVal != inlet_scale) {
+        // calculate new scale parameters as they changed
+        // optimize for evaluation
+        _postrack = 0;
+        _notecount = 0;
+        for(int i=0;i<128;i++) {
+        	if((1<<(i%12))&inlet_scale) {
+        		if(i<12) {
+        			_notecount = _notecount + 1;
+        		}
+        		_allowed[_postrack] = (i - 64) << 21;
+        		_postrack = _postrack + 1;
+        	}
+        }
+        for(int i=_postrack;i<128;i++) {
+        	_allowed[i] = _allowed[i-_postrack];
+        }
+    }
+    if (_degree != inlet_degree || _octave != inlet_octave || _scaleVal != inlet_scale
+        || _tonic != inlet_tonic) {
+        	_degree = inlet_degree;
+        	_tonic = inlet_tonic;
+        	_octave = inlet_octave;
+        	_scaleVal = inlet_scale;
+    		int outnoteidx = ((inlet_octave * _notecount) + _degree + _tonic) % 128;
+    		_out = _allowed[outnoteidx];
+    }
+    outlet_note = _out;]]></code.krate>
+   </obj.normal>
+</objdefs>

--- a/objects/rec/harmony/intNoteScale.axo
+++ b/objects/rec/harmony/intNoteScale.axo
@@ -1,6 +1,6 @@
 <objdefs appVersion="1.0.12">
    <obj.normal id="intNoteScale" uuid="939e3abc-1ecc-4805-b0b4-e4ab24e9ec80">
-      <sDescription>12 bit integer defines a scale (where 1s of binary string are allowed notes), note number and octave inputs are converted to a fractional note output
+      <sDescription>12 bit integer defines a scale (where 1s of binary string are allowed notes), note number and octave inputs are converted to a fractional note output, modified from harmony/note scale
       <author>Reductionist Earth Catalog</author>
       <license>BSD</license>
       <helpPatch>harmony.axh</helpPatch>


### PR DESCRIPTION
Modified harmony/note scale so that a 12 bit integer input defines the scale, along with some changes to note selection, and a773/quantizer, where binary toggle inputs are used to select the scale